### PR TITLE
Install blender 2.79

### DIFF
--- a/hr
+++ b/hr
@@ -1420,7 +1420,8 @@ install_head-deps() {
     add_ppa ppa:fkrull/deadsnakes
     # setup ruby2.3
     add_ppa ppa:brightbox/ruby-ng
-    add_ppa ppa:irie/blender
+    remove_ppa ppa:irie/blender
+    add_ppa ppa:thomas-schiex/blender
     $SUDO apt-get update
 
     local version=0.1.2

--- a/hr
+++ b/hr
@@ -209,7 +209,7 @@ add_ppa() {
 }
 
 remove_ppa() {
-    $SUDO add-apt-repository -yr $1
+    $SUDO add-apt-repository -y --remove $1
 }
 
 curl_cache() {


### PR DESCRIPTION
Per issue #9 -- This changes the ppa repository ti install blender 2.79

Testing this now, it seems that 2.79 is not compatible with our current blender animation files.  The animation won't play, I get errors.