### PR TITLE
removed deprecated ros-behaviour-scripting from OpenCog build

### DIFF
--- a/hr
+++ b/hr
@@ -16,8 +16,8 @@ HR_PREFIX=/opt/hansonrobotics
 
 HR_DEV_REPOS=(hansonrobotics/blender_api_msgs:HEAD/src hansonrobotics/blender_api:HEAD/src hansonrobotics/chatbot:HEAD/src hansonrobotics/basic_head_api:HEAD/src hansonrobotics/motors_safety:HEAD/src hansonrobotics/pau2motors:HEAD/src hansonrobotics/ros_pololu:HEAD/src hansonrobotics/webui:HEAD/src hansonrobotics/perception:HEAD/src hansonrobotics/pi_vision:HEAD/src hansonrobotics/performances:HEAD/src hansonrobotics/ros_tts:HEAD/src hansonrobotics/ttsserver:HEAD/src hansonrobotics/hr_reflexes:HEAD/src hansonrobotics/ros_face_recognition:HEAD/src hansonrobotics/hr_msgs:HEAD/src hansonrobotics/audio_stream:HEAD/src hansonrobotics/sys_monitor:HEAD/src hansonrobotics/ros_mongo:HEAD/src hansonrobotics/r2_behavior:HEAD/src hansonrobotics/eye_tracking:HEAD/src hansonrobotics/rospy_message_converter:HEAD/src)
 HR_LAUNCHPAD_REPOS=(hansonrobotics/launchpad:)
-HR_OPENCOG_DEV_REPOS=(hansonrobotics/cogutils:HROpenCog hansonrobotics/atomspace:HROpenCog hansonrobotics/opencog:HROpenCog hansonrobotics/ros-behavior-scripting:HROpenCog hansonrobotics/relex:HROpenCog hansonrobotics/external-tools:HROpenCog)
-OPENCOG_DEV_REPOS=(opencog/cogutil:OpenCog opencog/atomspace:OpenCog opencog/opencog:OpenCog opencog/ros-behavior-scripting:OpenCog opencog/relex:OpenCog opencog/external-tools:OpenCog)
+HR_OPENCOG_DEV_REPOS=(hansonrobotics/cogutils:HROpenCog hansonrobotics/atomspace:HROpenCog hansonrobotics/opencog:HROpenCog hansonrobotics/relex:HROpenCog hansonrobotics/external-tools:HROpenCog)
+OPENCOG_DEV_REPOS=(opencog/cogutil:OpenCog opencog/atomspace:OpenCog opencog/opencog:OpenCog opencog/relex:OpenCog opencog/external-tools:OpenCog)
 HR_LAUNCHPAD_DIR=$HR_WORKSPACE/launchpad
 HR_CONFIGS_DIR=$HR_LAUNCHPAD_DIR/configs
 HR_APT_SOURCE=/etc/apt/sources.list.d/head-latest.list
@@ -2515,8 +2515,7 @@ build_opencog() {
         repo=${args[1]}
         workdir=${args[2]}
         if [[ $repo != 'relex' && \
-              $repo != 'external-tools' && \
-              $repo != 'ros-behavior-scripting' ]]; then
+              $repo != 'external-tools' ]]; then
             if [[ ! -d $workdir/build ]]; then
                 mkdir $workdir/build
             fi
@@ -2524,14 +2523,6 @@ build_opencog() {
         fi
         if [[ $repo == 'relex' ]]; then
             cd $workdir && JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 ant build && $SUDO ant install
-        fi
-        if [[ $repo == 'ros-behavior-scripting' ]]; then
-            if [[ ! -d $workdir/build ]]; then
-                mkdir $workdir/build
-            fi
-            cd $workdir/build && \
-            source /opt/hansonrobotics/ros/setup.bash && \
-            cmake ..  && make -j$(nproc) && $SUDO make install
         fi
     done
 }


### PR DESCRIPTION
Build failed because of deprecated ros-behaviour-scripting. New best practice is to clone ghost_bridge into HEAD/src and let head stack build it. 